### PR TITLE
Allow to build remotely

### DIFF
--- a/addons/sync-godot/src/network/protocol.gd
+++ b/addons/sync-godot/src/network/protocol.gd
@@ -16,6 +16,9 @@ func _ready():
 
 
 func rebuild(template_path: String, inspector: Array, generator_payload: Array) -> void:
+	var file = File.new()
+	file.open(template_path, File.READ)
+	var template_content = file.get_as_text()
 	if not _client.is_connected_to_server():
 		_start_client()
 		_queue.append([template_path, inspector, generator_payload])
@@ -23,7 +26,7 @@ func rebuild(template_path: String, inspector: Array, generator_payload: Array) 
 
 	var msg := {}
 	msg["command"] = "build"
-	msg["path"] = template_path
+	msg["tpgn"] = template_content
 	msg["inspector"] = inspector
 	msg["inputs"] = generator_payload
 	_client.send(msg)


### PR DESCRIPTION
There is an issue when building Protongraph remotely, we should address this by passing the entire template as part of the payload when requesting a build.

Companion PR to this change: https://github.com/token-cjg/protongraph/pull/20